### PR TITLE
Make example code in the README compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ import hts
 
 # open a bam and look for the index.
 var b:Bam
-assert open(b, "test/HG02002.bam", index=true)
+open(b, "tests/HG02002.bam", index=true)
 
 for record in b:
-  if record.qual > 10:
+  if record.qual > 10u:
     echo record.chrom, record.start, record.stop
 
 # regional queries:
-for record in b.query('6', 30816675, 32816675):
+for record in b.query("6", 30816675, 32816675):
   if record.flag.proper_pair and record.flag.reverse:
     # cigar is an iterable of operations:
     for op in record.cigar:
@@ -47,9 +47,9 @@ for record in b.query('6', 30816675, 32816675):
 
     # tags are pulled with `aux`
     var mismatches = rec.aux("NM")
-    if mismatches != nil and mismatches.integer() < 3:
+    if mismatches != nil and mismatches.asInt.get < 3:
       var rg = rec.aux("RG")
-      echo rg.tostring()
+      echo rg.asString
 
 # cram requires an fasta to decode:
 var cram:Bam


### PR DESCRIPTION
Background - I was modeling some code after the examples in the README and was puzzled to find that compiling it in release mode caused it to cease functioning. I think this was due to the `assert open()` statements in the VCF being optimized away. 

I'm sure this is due to me being an extreme novice in Nim, but I thought perhaps adjusting the example code would help other novices. Right now this is just a commit to the first example to enable it to compile (not even sure if I've used the library properly).

The VCF example is a bit more involved and I thought I'd ask whether it'd be preferable to simply discard the return values of the open statements and info field retrieval or exhibit error checking before trying to push some updates to the VCF example.