### PR TITLE
vcfs from scratch

### DIFF
--- a/src/hts/private/hts_concat.h
+++ b/src/hts/private/hts_concat.h
@@ -672,7 +672,9 @@ int bcf_write(htsFile *fp, bcf_hdr_t *h, bcf1_t *v);
 void bcf_hdr_destroy(bcf_hdr_t *h);
 bcf1_t *bcf_dup(bcf1_t *src);
 void bcf_destroy(bcf1_t *v);
+int bcf_add_filter(const bcf_hdr_t *hdr, bcf1_t *line, int flt_id)
 int bcf_update_info(const bcf_hdr_t *hdr, bcf1_t *line, const char *key, const void *values, int n, int type);
+int bcf_update_alleles_str(const bcf_hdr_t *hdr, bcf1_t *line, char ***dst);
 
 int bcf_hdr_set_samples(bcf_hdr_t *hdr, const char *samples, int is_file);
 int bcf_subset_format(const bcf_hdr_t *hdr, bcf1_t *rec);
@@ -688,7 +690,7 @@ int bcf_update_format_string(const bcf_hdr_t *hdr, bcf1_t *line, const char *key
 int bcf_update_format(const bcf_hdr_t *hdr, bcf1_t *line, const char *key, const void *values, int n, int type);
 
 
-int vcf_parse(kstring_t *s, const bcf_hdr_t *h, bcf1_t *v); 
+int vcf_parse(kstring_t *s, const bcf_hdr_t *h, bcf1_t *v);
 int vcf_format(const bcf_hdr_t *h, const bcf1_t *v, kstring_t *s);
 
 hts_idx_t *bcf_index_load(char *fn);

--- a/src/hts/private/hts_concat.nim
+++ b/src/hts/private/hts_concat.nim
@@ -807,6 +807,10 @@ proc bcf_destroy*(v: ptr bcf1_t) {.cdecl, importc: "bcf_destroy", dynlib: libnam
 proc bcf_update_info*(hdr: ptr bcf_hdr_t; line: ptr bcf1_t; key: cstring;
                      values: pointer; n: cint; `type`: cint): cint {.cdecl,
     importc: "bcf_update_info", dynlib: libname.}
+proc bcf_add_filter*(hdr: ptr bcf_hdr_t; line: ptr bcf1_t; flt_id: cint;): cint {.cdecl,
+    importc: "bcf_add_filter", dynlib: libname.}
+proc bcf_update_alleles_str*(hdr: ptr bcf_hdr_t; line: ptr bcf1_t; alleles: cstring): cint {.cdecl,
+    importc: "bcf_update_alleles_str", dynlib: libname.}
 proc bcf_hdr_set_samples*(hdr: ptr bcf_hdr_t; samples: cstring; is_file: cint): cint {.
     cdecl, importc: "bcf_hdr_set_samples", dynlib: libname.}
 proc bcf_subset_format*(hdr: ptr bcf_hdr_t; rec: ptr bcf1_t): cint {.cdecl,

--- a/src/hts/vcf.nim
+++ b/src/hts/vcf.nim
@@ -332,7 +332,7 @@ proc set*(i:INFO, key:string, values:var seq[int32]): Status {.inline.} =
       values[0].addr.pointer, len(values).cint, BCF_HT_INT.cint)
   return Status(ret.int)
 
-proc destroy_variant*(v:Variant) =
+proc destroy_variant(v:Variant) =
   if v != nil and v.c != nil and v.own:
     bcf_destroy(v.c)
     v.c = nil
@@ -347,6 +347,11 @@ proc from_string*(v: var Variant, h: Header, s:var string) =
     v.c = bcf_init()
   if vcf_parse(str.addr, h.hdr, v.c) != 0:
    raise newException(ValueError, "hts-nim/Variant/from_string: error parsing variant:" & s)
+
+proc newVariant*(): Variant =
+  ## make an empty variant.
+  new(result, destroy_variant)
+  result.c = bcf_init()
 
 proc destroy_vcf(v:VCF) =
   bcf_hdr_destroy(v.header.hdr)

--- a/src/hts/vcf.nim
+++ b/src/hts/vcf.nim
@@ -119,24 +119,6 @@ proc from_string*(h: var Header, s:string) =
   if bcf_hdr_sync(h.hdr) != 0:
    raise newException(ValueError, "hts-nim/Header/from_string: error setting header with:" & s)
 
-proc init_header*(h: var Header, samples:seq[string] = @[]) =
-  var default_header = ("""##fileformat=VCFv4.2
-#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT""")
-  if len(samples) != 0:
-    default_header &= "	" & samples.join("	")
-  h.from_string(default_header)
-
-proc add_contig*(h:Header, ID:string, meta:tuple = ()): Status =
-  ## add a contig field to the header with the given values
-  var str = "##contig=<ID=" & ID
-  for key, value in fieldPairs(meta):
-    str &= "," & key & "=" & value
-  return h.add_string(str & ">")
-
-proc add_filter*(h:Header, ID:string, Description: string): Status =
-  ## add a FILTER field to the header with the given values
-  return h.add_string(format("##FILTER=<ID=$#,Description=\"$#\">", ID, Description))
-
 proc add_info*(h:Header, ID:string, Number:string, Type:string, Description: string): Status =
   ## add an INFO field to the header with the given values
   return h.add_string(format("##INFO=<ID=$#,Number=$#,Type=$#,Description=\"$#\">", ID, Number, Type, Description))
@@ -350,7 +332,7 @@ proc set*(i:INFO, key:string, values:var seq[int32]): Status {.inline.} =
       values[0].addr.pointer, len(values).cint, BCF_HT_INT.cint)
   return Status(ret.int)
 
-proc destroy_variant(v:Variant) =
+proc destroy_variant*(v:Variant) =
   if v != nil and v.c != nil and v.own:
     bcf_destroy(v.c)
     v.c = nil
@@ -365,23 +347,6 @@ proc from_string*(v: var Variant, h: Header, s:var string) =
     v.c = bcf_init()
   if vcf_parse(str.addr, h.hdr, v.c) != 0:
    raise newException(ValueError, "hts-nim/Variant/from_string: error parsing variant:" & s)
-
-proc add_filters*(v:Variant, filters:seq[string]) =
-  var filter_id: cint
-  for filter in filters:
-    filter_id = bcf_hdr_id2int(v.vcf.header.hdr, BCF_DT_ID, filter)
-    doAssert bcf_add_filter(v.vcf.header.hdr, v.c, filter_id) == 1
-
-proc new_variant*(v:VCF, contig: string, pos: int32, id:string=".", REF:string=".", ALT:string=".", qual:float = 0, filters:seq[string] = @[]): Variant =
-  new(result, destroy_variant)
-  result.vcf = v
-  result.c = bcf_init()
-  result.c.rid = bcf_hdr_name2id(result.vcf.header.hdr, contig)
-  result.c.pos = pos
-  result.c.d.id = id
-  doAssert bcf_update_alleles_str(result.vcf.header.hdr, result.c, REF & "," & ALT) == 0
-  result.c.qual = qual
-  result.add_filters(filters)
 
 proc destroy_vcf(v:VCF) =
   bcf_hdr_destroy(v.header.hdr)


### PR DESCRIPTION
Addresses #30.

Exposes 2 other htslib functions and adds new wrapper functions to be able to cleanly write new vcf headers and variants.

Could not figure out missing value for quality since `bcf_float_missing` did not work.

Ex:
```nim
import hts/vcf

var h:Header

init_header(h, samples = @["mysample", "mysample2"])
doAssert h.add_contig("1") == Status.OK
doAssert h.add_contig("2",(species:"Human")) == Status.OK
doAssert h.add_filter("FLAG1", "Dummy") == Status.OK
doAssert h.add_filter("FLAG2", "Dummy") == Status.OK
doAssert h.add_info("DP", "1", "Integer", "total reads covering this site") == Status.OK
doAssert h.add_format("Test", "1", "String", "random string") == Status.OK

var ovcf:VCF

if not open(ovcf, "out.vcf", mode="w"):
  quit "could not open vcf"

ovcf.header = h
doAssert ovcf.write_header

var vr : Variant
vr = ovcf.new_variant("1", 100, REF="G", ALT="T", filters = @["FLAG2"], qual=60)
var val = 35
discard vr.info.set("DP", val)
var val2 = @[".","test"]
discard vr.format.set("Test", val2)
doAssert ovcf.write_variant(vr)

ovcf.close()
```