### PR TITLE
Fix warnings

### DIFF
--- a/hts.nimble
+++ b/hts.nimble
@@ -8,7 +8,7 @@ license       = "MIT"
 
 # Dependencies
 
-requires "nim >= 0.18.0" 
+requires "nim >= 0.19.9"
 srcDir = "src"
 
 skipDirs = @["tests"]

--- a/src/hts/bam/auxtags.nim
+++ b/src/hts/bam/auxtags.nim
@@ -1,6 +1,6 @@
 import ../simpleoption
 export simpleoption
-import strformat
+from strformat import `&`
 
 proc delete_tag*(r:Record, itag:string): bool {.inline.} =
   ## remove the tag from the record return a bool indicating success.

--- a/src/hts/bgzf.nim
+++ b/src/hts/bgzf.nim
@@ -1,6 +1,4 @@
 import ./private/hts_concat
-import strutils
-import os
 
 type
   BGZ* = ref object of RootObj

--- a/src/hts/bgzf/bgzi.nim
+++ b/src/hts/bgzf/bgzi.nim
@@ -1,8 +1,6 @@
 import ../private/hts_concat
 import ../bgzf
 import ../csi
-import strutils
-import os
 
 type
   BGZI* = ref object of RootObj

--- a/src/hts/csi.nim
+++ b/src/hts/csi.nim
@@ -1,5 +1,4 @@
 import ./private/hts_concat
-import ./bgzf
 
 type
   CSI* = ref object

--- a/src/hts/private/hts_concat.nim
+++ b/src/hts/private/hts_concat.nim
@@ -243,7 +243,7 @@ type
 ## ###########################
 
 type
-  INNER_C_UNION_hts_concat_212* {.bycopy.} = object {.union.}
+  INNER_C_UNION_hts_concat_212* {.bycopy, union.} = object
     bgzf*: ptr BGZF
     cram*: ptr cram_fd
     hfile*: ptr hFILE
@@ -536,7 +536,7 @@ template bam_cigar_gen*(l, o: untyped): untyped =
   ((l) shl BAM_CIGAR_SHIFT or (o))
 
 type
-  bam_pileup_cd* {.bycopy.} = object {.union.}
+  bam_pileup_cd* {.bycopy, union.} = object
     p*: pointer
     i*: int64
     f*: cdouble
@@ -653,7 +653,7 @@ const
 ##
 
 type
-  INNER_C_UNION_hts_concat_557* {.bycopy.} = object {.union.}
+  INNER_C_UNION_hts_concat_557* {.bycopy, union.} = object
     i*: int32                  ##  integer value
     f*: cfloat                 ##  float value
 


### PR DESCRIPTION
```
hts-0.2.20/hts/private/hts_concat.nim(246, 53) Warning: type pragmas follow the type name; this form of writing pragmas is deprecated [Deprecated]
hts-0.2.20/hts/private/hts_concat.nim(539, 38) Warning: type pragmas follow the type name; this form of writing pragmas is deprecated [Deprecated]
hts-0.2.20/hts/private/hts_concat.nim(656, 53) Warning: type pragmas follow the type name; this form of writing pragmas is deprecated [Deprecated]
hts-0.2.20/hts/bam/auxtags.nim(3, 8) Warning: imported and not used: 'strformat' [UnusedImport]
hts-0.2.20/hts/bgzf.nim(3, 8) Warning: imported and not used: 'os' [UnusedImport]
hts-0.2.20/hts/bgzf.nim(2, 8) Warning: imported and not used: 'strutils' [UnusedImport]
hts-0.2.20/hts/csi.nim(2, 8) Warning: imported and not used: 'bgzf' [UnusedImport]
hts-0.2.20/hts/bgzf/bgzi.nim(4, 8) Warning: imported and not used: 'strutils' [UnusedImport]
hts-0.2.20/hts/bgzf/bgzi.nim(5, 8) Warning: imported and not used: 'os' [UnusedImport]
```
The first three are with nim-0.20.2+, and the rest are only with `devel`.

* https://nim-lang.org/blog/2019/06/06/version-0200-released.html

> Pragma syntax is now consistent. Previous syntax where type pragmas did not follow the type name is now deprecated.... See nim-lang/Nim#8514 ... for further details.

I checked whether my change works with nim-0.18.0. It does, but that's already broken here from
```
src/hts/bam/cigar.nim(9, 17) Error: invalid indentation
```
So I am also bumping the required **nim** in `.nimble`.

Also, I have fixed the `UnusedImport` warnings with Nim-devel, but please double-check that.