### PR TITLE
Added ability to set ID in VCF Variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ for rec in v.query("1:15600-18250"):
 
 ```
 
+## TSV files
+
+```nim
+import hts
+
+var b: BGZI
+b.ropen_bgzi("ti.txt.gz")  # Requires a CSI index: ti.txt.gz.csi
+
+for reg in b.query("aaa", 1, 5):
+  echo reg
+```
+
+
 ## Setup / Installation
 
 `hts-nim` requires that [htslib](https://github.com/samtools/htslib) is installed and the shared library is available

--- a/README.md
+++ b/README.md
@@ -105,8 +105,7 @@ for rec in v.query("1:15600-18250"):
 ```nim
 import hts
 
-var b: BGZI
-b.ropen_bgzi("ti.txt.gz")  # Requires a CSI index: ti.txt.gz.csi
+var b: BGZI = ropen_bgzi("ti.txt.gz")  # Requires a CSI index: ti.txt.gz.csi
 
 for reg in b.query("aaa", 1, 5):
   echo reg

--- a/src/hts/private/hts_concat.h
+++ b/src/hts/private/hts_concat.h
@@ -687,6 +687,7 @@ void bcf_hdr_destroy(bcf_hdr_t *h);
 bcf1_t *bcf_dup(bcf1_t *src);
 void bcf_destroy(bcf1_t *v);
 int bcf_add_filter(const bcf_hdr_t *hdr, bcf1_t *line, int flt_id);
+int bcf_update_id(const bcf_hdr_t *hdr, bcf1_t *line, const char *id);
 int bcf_update_info(const bcf_hdr_t *hdr, bcf1_t *line, const char *key, const void *values, int n, int type);
 int bcf_update_alleles_str(const bcf_hdr_t *hdr, bcf1_t *line, char ***dst);
 

--- a/src/hts/private/hts_concat.nim
+++ b/src/hts/private/hts_concat.nim
@@ -824,6 +824,8 @@ proc bcf_dup*(src: ptr bcf1_t): ptr bcf1_t {.cdecl, importc: "bcf_dup", dynlib: 
 proc bcf_destroy*(v: ptr bcf1_t) {.cdecl, importc: "bcf_destroy", dynlib: libname.}
 proc bcf_add_filter*(hdr: ptr bcf_hdr_t; line: ptr bcf1_t; flt_id: cint): cint {.cdecl,
     importc: "bcf_add_filter", dynlib: libname.}
+proc bcf_update_id*(hdr: ptr bcf_hdr_t; line: ptr bcf1_t; id: cstring): cint {.cdecl,
+    importc: "bcf_update_id", dynlib: libname.}
 proc bcf_update_info*(hdr: ptr bcf_hdr_t; line: ptr bcf1_t; key: cstring;
                      values: pointer; n: cint; `type`: cint): cint {.cdecl,
     importc: "bcf_update_info", dynlib: libname.}

--- a/src/hts/vcf.nim
+++ b/src/hts/vcf.nim
@@ -703,7 +703,7 @@ proc ID*(v:Variant): cstring {.inline.} =
 
 proc `ID=`*(v:Variant, value: string) {.inline.} =
   ## Set the ID value, third column in the VCF spec.
-  v.c.d.id = value
+  doAssert(bcf_update_id(v.vcf.header.hdr, v.c, value) == 0)
 
 proc FILTER*(v:Variant): string {.inline.} =
   ## Return a string representation of the FILTER will be ';' delimited for multiple values

--- a/src/hts/vcf.nim
+++ b/src/hts/vcf.nim
@@ -701,6 +701,10 @@ proc ID*(v:Variant): cstring {.inline.} =
   ## the VCF ID field
   return v.c.d.id
 
+proc `ID=`*(v:Variant, value: string) {.inline.} =
+  ## Set the ID value, third column in the VCF spec.
+  v.c.d.id = value
+
 proc FILTER*(v:Variant): string {.inline.} =
   ## Return a string representation of the FILTER will be ';' delimited for multiple values
   if v.c.d.n_flt == 0: return "PASS"

--- a/tests/vcftest.nim
+++ b/tests/vcftest.nim
@@ -279,6 +279,13 @@ suite "vcf suite":
     global_variant.QUAL = 55
     check global_variant.QUAL == 55
 
+  test "set id":
+    check global_variant.ID == "."
+
+    global_variant.ID = "rs0123456789"
+
+    check global_variant.ID == "rs0123456789"
+    check global_variant.tostring.split('\t')[..2] == @["1", "10172", "rs0123456789"]
 
   test "new from string":
     var v:VCF


### PR DESCRIPTION
The Variant ID field is quite buried into `v.c.d.id`.

I also added a small TSV reading sample to the Readme.