### PR TITLE
fix `csize_t` for Nim 1.0.x

### DIFF
--- a/src/hts/private/hts_concat.nim
+++ b/src/hts/private/hts_concat.nim
@@ -8,9 +8,10 @@ elif defined(macosx):
 else:
   const
     libname* = "libhts.so"
-when NimMajor < 1:
-    type
-        csize_t* = csize
+
+when (NimMajor, NimMinor) < (1, 1):
+  type
+    csize_t* = csize
 ##
 ## enum hts_fmt_option {
 ##     // CRAM specific


### PR DESCRIPTION
The original idea in #67 was a good one, the only problem was that the author didn't test it with Nim 1.0.x:

> I tested on 0.19.9, 1.2.0, and fairly recent devel

which still didn't have `csize_t`.