### PR TITLE
remove deadCodeElim statement

### DIFF
--- a/src/hts/private/hts_concat.nim
+++ b/src/hts/private/hts_concat.nim
@@ -1,4 +1,3 @@
- {.deadCodeElim: on.}
 when defined(windows):
   const
     libname* = "libhts.dll"


### PR DESCRIPTION
Hello @brentp
deadCodeElim is always enabled and first line indentation will become an error soon => nim-lang/Nim#19666
see also https://github.com/nim-lang/c2nim/issues/20