### PR TITLE
remove shallow for ARC/ORC

### DIFF
--- a/src/hts/bgzf/bgzi.nim
+++ b/src/hts/bgzf/bgzi.nim
@@ -68,7 +68,8 @@ iterator query*(bi: BGZI, chrom: string, start:int64, stop:int64): string {.inli
 
   var kstr = kstring_t(s:nil, m:0, l:0)
   var outstr = newStringOfCap(10000)
-  shallow(outstr)
+  when not defined(gcArc) and not defined(gcOrc):
+    shallow(outstr)
 
   while hts_itr_next(bi.bgz.cptr, itr, kstr.addr, bi.csi.tbx.addr) > 0:
     fastSubStr(outstr, kstr.s, 0, int(kstr.l))


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/pull/20502

shallow doesn't work for ARC/ORC.