### PR TITLE
Iterator failures should raise an exception, rather than simply write to stderr

### DIFF
--- a/hts.nimble
+++ b/hts.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.30"
+version       = "0.3.31"
 author        = "Brent Pedersen"
 description   = "hts (bam/sam) for nim"
 license       = "MIT"

--- a/src/hts/bam.nim
+++ b/src/hts/bam.nim
@@ -31,7 +31,7 @@ type
 
   IndexStats* = tuple[mapped: uint64, unmapped: uint64]
 
-  BamError* = ref object of ValueError
+  BamError* = object of ValueError
 
 proc finalize_header(h: Header) =
   sam_hdr_destroy(h.hdr)
@@ -267,7 +267,7 @@ iterator query*(bam: Bam, chrom:string, start:int=0, stop:int=0): Record =
       slen = sam_itr_next(bam.hts, qiter, bam.rec.b)
     hts_itr_destroy(qiter)
     if slen < -1:
-      raise newException(IOError, &"[hts-nim] error:{slen} in bam.query for tid:{chrom} {start}..{stop}")
+      raise newException(BamError, &"[hts-nim] error:{slen} in bam.query for tid:{chrom} {start}..{stop}")
 
 
 iterator query*(bam: Bam, tid:int, start:int=0, stop:int=(-1)): Record =
@@ -284,7 +284,7 @@ iterator query*(bam: Bam, tid:int, start:int=0, stop:int=(-1)): Record =
       slen = sam_itr_next(bam.hts, qiter, bam.rec.b)
     hts_itr_destroy(qiter)
     if slen < -1:
-      raise newException(IOError, &"[hts-nim] error:{slen} in bam.query for tid:{tid} {start}..{stop}")
+      raise newException(BamError, &"[hts-nim] error:{slen} in bam.query for tid:{tid} {start}..{stop}")
 
 proc `$`*(r: Record): string =
     return format("Record($1:$2-$3):$4", [r.chrom, $r.start, $r.stop, r.qname])

--- a/src/hts/bam.nim
+++ b/src/hts/bam.nim
@@ -267,7 +267,7 @@ iterator query*(bam: Bam, chrom:string, start:int=0, stop:int=0): Record =
       slen = sam_itr_next(bam.hts, qiter, bam.rec.b)
     hts_itr_destroy(qiter)
     if slen < -1:
-      stderr.write_line(&"[hts-nim] error:{slen} in bam.query for tid:{chrom} {start}..{stop}")
+      raise newException(IOError, &"[hts-nim] error:{slen} in bam.query for tid:{chrom} {start}..{stop}")
 
 
 iterator query*(bam: Bam, tid:int, start:int=0, stop:int=(-1)): Record =
@@ -284,7 +284,7 @@ iterator query*(bam: Bam, tid:int, start:int=0, stop:int=(-1)): Record =
       slen = sam_itr_next(bam.hts, qiter, bam.rec.b)
     hts_itr_destroy(qiter)
     if slen < -1:
-      stderr.write_line(&"[hts-nim] error:{slen} in bam.queryi for tid:{tid} {start}..{stop}")
+      raise newException(IOError, &"[hts-nim] error:{slen} in bam.query for tid:{tid} {start}..{stop}")
 
 proc `$`*(r: Record): string =
     return format("Record($1:$2-$3):$4", [r.chrom, $r.start, $r.stop, r.qname])


### PR DESCRIPTION
`sam_itr_next` returning an error is generally fatal, due to a corrupted BAM or filesystem instability. The current approach of simply logging to stderr is suboptimal, since it means that any iterator failures cannot be caught and handled by whatever is invoking `Bam.query()`.

(See [dependent pull request in mosdepth](https://github.com/brentp/mosdepth/pull/265), which relies on these exceptions being thrown to cause a nonzero exit upon iterator failure.)